### PR TITLE
Allow access from `zed-industries/extensions`

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -8,7 +8,7 @@ primary_region = 'ewr'
 
 [env]
 PORT = "8080"
-ALLOWED_REPOS = "zed-industries/zed"
+ALLOWED_REPOS = "zed-industries/zed,zed-industries/extensions"
 
 [http_service]
 internal_port = 8080


### PR DESCRIPTION
This PR updates the list of allowed repos to also allow [zed-industries/extensions](https://github.com/zed-industries/extensions).